### PR TITLE
Add multi-contact search for sales lead researcher

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -37,7 +37,7 @@ Check out a variety of sample implementations of the SDK in the examples section
 
     - **customer_service**: Example customer service system for an airline.
     - **research_bot**: Simple deep research clone.
-    - **sales_lead_researcher**: Collect CRM information about publishing contacts.
+    - **sales_lead_researcher**: Collect CRM information about publishing contacts, automatically finding contacts when only a company is provided.
 
 - **[voice](https://github.com/openai/openai-agents-python/tree/main/examples/voice):**
   See examples of voice agents, using our TTS and STT models.

--- a/docs/ja/examples.md
+++ b/docs/ja/examples.md
@@ -40,7 +40,7 @@ search:
 
     - **customer_service**: 航空会社向けカスタマーサービスシステムの例
     - **research_bot**: シンプルなディープリサーチクローン
-    - **sales_lead_researcher**: 出版社向けリード情報を収集する例
+    - **sales_lead_researcher**: 出版社向けリード情報を収集する例。会社名のみを入力した場合でも候補者を自動検索します
 
 - **[voice](https://github.com/openai/openai-agents-python/tree/main/examples/voice):**  
   TTS と STT モデルを用いた音声エージェントの例をご覧ください。

--- a/examples/sales_lead_researcher/README.md
+++ b/examples/sales_lead_researcher/README.md
@@ -8,4 +8,4 @@ Run it with:
 python -m examples.sales_lead_researcher.main
 ```
 
-You will be prompted to enter company and person pairs. Provide either `Company, Person` or just the company name. The agents will search the web (LinkedIn and company websites) in parallel and return structured lead information.
+You will be prompted to enter company and person pairs. Provide either `Company, Person` or just the company name. If only the company is given, the workflow will attempt to find multiple relevant contacts and gather information for each. The agents will search the web (LinkedIn and company websites) in parallel and return structured lead information.

--- a/examples/sales_lead_researcher/agents/contact_finder_agent.py
+++ b/examples/sales_lead_researcher/agents/contact_finder_agent.py
@@ -4,10 +4,11 @@ from agents import Agent, WebSearchTool
 from agents.model_settings import ModelSettings
 
 INSTRUCTIONS = (
-    "You find the best editorial contact at a publishing company. Given just the company's name, "
-    "search the web to identify a likely decision maker we could reach out to. "
+    "You find editorial contacts at a publishing company. Given just the company's name, "
+    "search the web to identify as many likely decision makers as you can. "
     "Prefer people responsible for content or editorial decisions. "
-    "Return their full name and title. If unsure, make your best guess based on available information."
+    "Return a list of their full names and titles, in order of relevance. "
+    "If unsure, make your best guess based on available information."
 )
 
 
@@ -21,5 +22,5 @@ contact_finder_agent = Agent(
     instructions=INSTRUCTIONS,
     tools=[WebSearchTool()],
     model_settings=ModelSettings(tool_choice="required"),
-    output_type=ContactInfo,
+    output_type=list[ContactInfo],
 )

--- a/examples/sales_lead_researcher/manager.py
+++ b/examples/sales_lead_researcher/manager.py
@@ -31,19 +31,33 @@ class SalesLeadResearcher:
             results: list[LeadInfo] = []
             num_done = 0
             for task in asyncio.as_completed(tasks):
-                result = await task
-                results.append(result)
+                leads = await task
+                results.extend(leads)
                 num_done += 1
-                self.printer.update_item("progress", f"Processed {num_done}/{len(tasks)} leads")
+                self.printer.update_item(
+                    "progress",
+                    f"Processed {num_done}/{len(tasks)} companies",
+                )
             self.printer.mark_item_done("progress")
             self.printer.end()
         return results
 
-    async def _process(self, company: str, person: str | None) -> LeadInfo:
-        if not person:
+    async def _process(self, company: str, person: str | None) -> list[LeadInfo]:
+        people: list[str]
+        if person:
+            people = [person]
+        else:
             result = await Runner.run(contact_finder_agent, company)
-            info = result.final_output_as(ContactInfo)
-            person = info.full_name
-        input_data = f"Person: {person}\nCompany: {company}"
-        result = await Runner.run(info_agent, input_data)
-        return result.final_output_as(LeadInfo)
+            infos = result.final_output_as(list[ContactInfo])
+            people = [info.full_name for info in infos]
+
+        tasks = [
+            asyncio.create_task(Runner.run(info_agent, f"Person: {p}\nCompany: {company}"))
+            for p in people
+        ]
+
+        leads: list[LeadInfo] = []
+        for task in asyncio.as_completed(tasks):
+            res = await task
+            leads.append(res.final_output_as(LeadInfo))
+        return leads


### PR DESCRIPTION
### Summary
- find multiple contacts in ContactFinderAgent and return a list
- process all contacts in `SalesLeadResearcher`
- document the behavior in README and docs

### Test plan
- `ruff check examples/sales_lead_researcher/agents/contact_finder_agent.py examples/sales_lead_researcher/manager.py`
- `mypy examples/sales_lead_researcher` *(fails: Cannot find implementation or library stub for module named "pydantic")*
- `make format` *(fails: No route to host)*
- `make lint` *(fails: No route to host)*
- `make mypy` *(fails: No route to host)*
- `make tests` *(fails: No route to host)*
